### PR TITLE
Fix to ensure support for both Livewire v3 and v4

### DIFF
--- a/src/Features/SupportSignedActions/SupportSignedActions.php
+++ b/src/Features/SupportSignedActions/SupportSignedActions.php
@@ -18,7 +18,7 @@ class SupportSignedActions extends ComponentHook
 
     public static ?int $ttl = null;
 
-    public function call($method, $params, $returnEarly, $metadata, $componentContext)
+    public function call($method, $params, $returnEarly, $metadata = null, $componentContext = null)
     {
         if (self::$enabled === false) {
             return;


### PR DESCRIPTION
Fixes https://github.com/wire-elements/livewire-strict/issues/4

### Problem

Version 2.0.1 added support for Livewire 4 by changing the `call()` method signature in `SupportSignedActions` to accept 5 parameters (`$method`, `$params`, `$returnEarly`, `$metadata`, `$componentContext`). However, Livewire 3's `ComponentHook` only passes 3 arguments to `call()`, resulting in:

```
Too few arguments to function SupportSignedActions::call(), 3 passed in ComponentHook.php on line 41 and exactly 5 expected
```

This breaks all Livewire 3 applications that update to livewire-strict 2.0.1.

### Fix

Made `$metadata` and `$componentContext` optional by defaulting them to `null`. Since neither parameter is used in the method body, this is safe and maintains compatibility with both Livewire 3 (3 args) and Livewire 4 (5 args).
